### PR TITLE
Added published by default to CV

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,7 @@ class User < ApplicationRecord
 
   def confirm
     self.confirmed_at = Time.now.utc
+    cv.published = true
     if unconfirmed_email.present?
       self.email = unconfirmed_email
       self.unconfirmed_email = nil

--- a/app/views/cvs/show.html.erb
+++ b/app/views/cvs/show.html.erb
@@ -2,15 +2,10 @@
 ================================================== -->
 <div class="container cvpage pb-40 pb-md-80">
   <% if can? :update, @cv %>
-    <% if @cv.published? %>
+    <% unless @cv.published? %>
       <p class="border-bottom border-primary text-muted py-3 mb-0">
         <i class="icon-info mr-2"></i>
-        <%= t('content.main.cv.show.published') %>
-      </p>
-    <% else %>
-      <p class="border-bottom border-primary text-muted py-3 mb-0">
-        <i class="icon-info mr-2"></i>
-        <%= t('content.main.cv.show.unpublished') %>
+        <%= t('content.main.cv.show.unpublished_html') %>
       </p>
     <% end %>
   <% end %>

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -124,8 +124,7 @@ en:
           prefer_not_to_disclose: "Prefer not to disclose"
           male: "Male"
           female: "Female"
-          published: "Your resume is publised and visible to job providers and your last name and contact data will be published only on the pdf version that you can download. On the online version, when published, you’ll have a contact form."
-          unpublished: "Your resume is only visible to you until you publish and your last name and contact data will be published only on the pdf version that you can download. On the online version, when published, you’ll have a contact form."
+          unpublished_html: "Your resume is not visible to job providers. Remember to <b>publish it.!!!</b>"
           authorization_statement: "Authorization Statement (max. 255 characters)"
           authorization:
             title: "Authorization Statement"

--- a/config/locales/app.it.yml
+++ b/config/locales/app.it.yml
@@ -124,8 +124,7 @@ it:
           prefer_not_to_disclose: "Preferisco non rivelare"
           male: "Maschile"
           female: "Femminile"
-          published: "Il tuo curriculum è pubblicato e visibile ai datori di lavoro"
-          unpublished: "Il tuo curriculum è visibile solo a te fino a quando non pubblichi e il tuo cognome e i dati di contatto saranno pubblicati solo sulla versione pdf che puoi scaricare. Nella versione online, una volta pubblicato, avrai un modulo di contatto."
+          unpublished_html: "Il tuo curriculum non è visibile ai fornitori di lavoro. Ricordati di <b>pubblicarlo.!!!</b>"
           authorization_statement: "Dichiarazione di autorizzazione (massimo 255 caratteri)"
           authorization:
             title: "Dichiarazione di autorizzazione"

--- a/lib/tasks/update_cvs_to_published.rake
+++ b/lib/tasks/update_cvs_to_published.rake
@@ -1,0 +1,8 @@
+namespace :cvs do
+desc 'update confirmed users cv to published'
+  task update_cvs_to_published: :environment do
+    Cv.joins(:user).where('users.confirmed_at IS NOT NULL AND published = ?', false).each do |cv|
+      cv.update_column(:published, true)
+    end
+  end
+end

--- a/lib/tasks/update_cvs_to_published.rake
+++ b/lib/tasks/update_cvs_to_published.rake
@@ -1,5 +1,5 @@
 namespace :cvs do
-desc 'update confirmed users cv to published'
+  desc 'update confirmed users cv to published'
   task update_cvs_to_published: :environment do
     Cv.joins(:user).where('users.confirmed_at IS NOT NULL AND published = ?', false).each do |cv|
       cv.update_column(:published, true)


### PR DESCRIPTION
Project: #309 
Issue: #340 
Added default publish to CV whenever user creates and then confirms his account.

**1. View when account is unpublished**
![Screenshot from 2022-03-04 15-20-40](https://user-images.githubusercontent.com/80153678/156745591-55d869eb-dcd4-477d-b690-939fcd84c034.png)

**2. View when account is published**

![Screenshot from 2022-03-04 15-20-31](https://user-images.githubusercontent.com/80153678/156745602-413a63d4-b477-4200-b987-94a31e8f8dfb.png)
